### PR TITLE
Fixing null returns for fileContents in determineBaseDensity for Android

### DIFF
--- a/Generate Android Assets.jstalk
+++ b/Generate Android Assets.jstalk
@@ -55,7 +55,7 @@ library.sandbox = {
         } else {
             var fileManager = [NSFileManager defaultManager];
             var fileContents = [NSString stringWithContentsOfFile:configFile];
-            log(fileContents);
+
             if (fileContents != null)
             {
                 if (hit = fileContents.match(/^base_density:([a-z]*)/)) {

--- a/Generate Android Assets.jstalk
+++ b/Generate Android Assets.jstalk
@@ -5,125 +5,131 @@
 var library = {}
 library.sandbox = {
     // Utility: display a modal with message
-    debug: function(message){
-	var app = [NSApplication sharedApplication];
-	[app displayDialog:message withTitle:"Message"];
+    debug: function(message) {
+        var app = [NSApplication sharedApplication];
+        [app displayDialog:message withTitle:"Message"];
     },
     // each-like iterator for Obj-C types
-    forEachObj: function(array, callback){
-	var count = [array count];
-	for (var i = 0; i < count; i++){
-	    var el = [array objectAtIndex: i];
-	    callback(el);
-	}
+    forEachObj: function(array, callback) {
+        var count = [array count];
+        for (var i = 0; i < count; i++) {
+            var el = [array objectAtIndex: i];
+            callback(el);
+        }
     },
-    openInFinder: function(path){
-	var finder_task = [[NSTask alloc] init],
-	open_finder_args = [NSArray arrayWithObjects:"-R", path, nil];
+    openInFinder: function(path) {
+        var finder_task = [[NSTask alloc] init],
+        open_finder_args = [NSArray arrayWithObjects:"-R", path, nil];
 
-	[finder_task setLaunchPath:"/usr/bin/open"];
-	[finder_task setArguments:open_finder_args];
-	[finder_task launch];
+        [finder_task setLaunchPath:"/usr/bin/open"];
+        [finder_task setArguments:open_finder_args];
+        [finder_task launch];
     },
     configFileName: ".android_assets",
-    getDocumentConfigFilePath: function(documentUrl){
-	var localConfigFile = [[documentUrl URLByDeletingLastPathComponent] URLByAppendingPathComponent: library.sandbox.configFileName];
-	return localConfigFile;
+    getDocumentConfigFilePath: function(documentUrl) {
+        var localConfigFile = [[documentUrl URLByDeletingLastPathComponent] URLByAppendingPathComponent: library.sandbox.configFileName];
+        return localConfigFile;
     },
-    findConfigFile: function(documentUrl){
-	var fileManager = [NSFileManager defaultManager];
-	var configFileName = library.sandbox.configFileName;
+    findConfigFile: function(documentUrl) {
+        var fileManager = [NSFileManager defaultManager];
+        var configFileName = library.sandbox.configFileName;
 
-	var localConfigFile = library.sandbox.getDocumentConfigFilePath(documentUrl);
+        var localConfigFile = library.sandbox.getDocumentConfigFilePath(documentUrl);
 
-	var userConfigFilePath = [NSString stringWithString:"~/" + configFileName];
-	var userConfigFile = [userConfigFilePath stringByExpandingTildeInPath];
+        var userConfigFilePath = [NSString stringWithString:"~/" + configFileName];
+        var userConfigFile = [userConfigFilePath stringByExpandingTildeInPath];
 
 
-	if ([fileManager fileExistsAtPath:[localConfigFile path]]){
-	    return localConfigFile;
-	}
+        if ([fileManager fileExistsAtPath:[localConfigFile path]]) {
+            return localConfigFile;
+        }
 
-	if ([fileManager fileExistsAtPath:userConfigFile]){
-	    return userConfigFile;
-	}
+        if ([fileManager fileExistsAtPath:userConfigFile]) {
+            return userConfigFile;
+        }
     },
-    determineBaseDensity: function(documentUrl){
-	var configFile = this.findConfigFile(documentUrl);
-	if (configFile == null) {
-	    log("No config file found");
-	} else {
-	    var fileManager = [NSFileManager defaultManager];
-	    var fileContents = [NSString stringWithContentsOfFile:configFile];
-	    if (hit = fileContents.match(/^base_density:([a-z]*)/)){
-		var density = hit[1];
-		log("Found base density: " + density + ", returning");
-		return density;
-	    } else {
-		log("Found config file, but no base_density specified in it");
-	    }
-	}
-	log("Returning default base density");
-	return null;
+    determineBaseDensity: function(documentUrl) {
+        var configFile = this.findConfigFile(documentUrl);
+        if (configFile == null) {
+            log("No config file found");
+        } else {
+            var fileManager = [NSFileManager defaultManager];
+            var fileContents = [NSString stringWithContentsOfFile:configFile];
+            log(fileContents);
+            if (fileContents != null)
+            {
+                if (hit = fileContents.match(/^base_density:([a-z]*)/)) {
+                    var density = hit[1];
+                    log("Found base density: " + density + ", returning");
+                    return density;
+                } else {
+                    log("Found config file, but no base_density specified in it");
+                }
+            }
+            else
+            {
+                log("fileContents is null!");
+            }
+        }
+        log("Returning default base density");
+        return null;
     },
-    getDensityFactors: function(baseDensityName){
-	log("Looking for factor " + baseDensityName);
-	var factors = {
-	    "mdpi":0.5,
-	    "hdpi": 0.75,
-	    "xhdpi": 1,
-	    "xxhdpi": 1.5,
-	    "xxxhdpi": 2};
-	var baseDensityFactor = factors[baseDensityName];
-	var result = {};
-	for (var key in factors){
-	    result[key] = factors[key] / baseDensityFactor;
-	}
-	return result;
+    getDensityFactors: function(baseDensityName) {
+        log("Looking for factor " + baseDensityName);
+        var factors = {
+            "mdpi":0.5,
+            "hdpi": 0.75,
+            "xhdpi": 1,
+            "xxhdpi": 1.5,
+            "xxxhdpi": 2};
+        var baseDensityFactor = factors[baseDensityName];
+        var result = {};
+        for (var key in factors) {
+            result[key] = factors[key] / baseDensityFactor;
+        }
+        return result;
     }
 }
 
-function main(){
+function main() {
     var fileUrl = [doc fileURL];
     if (fileUrl == null) {
-	alert("You need to save your document for me to know where to save it");
-	return;
+        alert("You need to save your document for me to know where to save it");
+        return;
     }
 
 
     var density = library.sandbox.determineBaseDensity([doc fileURL]);
     if (density == null) {
-	density = askForDefaultDensity();
-	var _contents = "base_density:"+density+"\n";
-	var err;
-	var contents = [NSString stringWithString:_contents];
+        density = askForDefaultDensity();
+        var _contents = "base_density:"+density+"\n";
+        var err;
+        var contents = [NSString stringWithString:_contents];
 
-	var path = library.sandbox.getDocumentConfigFilePath([doc fileURL]);
-	log("Will save config file into " + path);
-	var result = [contents writeToURL:path atomically:true];
-	log("Result is " + result);
+        var path = library.sandbox.getDocumentConfigFilePath([doc fileURL]);
+        log("Will save config file into " + path);
+        var result = [contents writeToURL:path atomically:true];
+        log("Result is " + result);
     }
-
 
     var factors = library.sandbox.getDensityFactors(density);
 
-
     var base_dir = get_dir_from_prompt(get_cwd());
-    if (base_dir == null){
-	alert("Not saving any assets");
-	return;
+    if (base_dir == null) {
+        alert("Not saving any assets");
+        return;
     }
 
     //process the selected slices
     var slicesToOutput = selection;
-    library.sandbox.forEachObj(slicesToOutput, function(slice){
-	process_slice(slice, doc, base_dir, factors);
+    library.sandbox.forEachObj(slicesToOutput, function(slice) {
+        process_slice(slice, doc, base_dir, factors);
     });
 
     library.sandbox.openInFinder(base_dir + "/drawable-hdpi");
 }
 
-function alert(msg){
+function alert(msg) {
     var app = [NSApplication sharedApplication];
     [app displayDialog:msg withTitle:"Hey"];
 }
@@ -131,7 +137,7 @@ function alert(msg){
 // Return current working directory
 // This works better for the designer's workflow, as they mostly want to
 // save assets in the current directory
-function get_cwd(){
+function get_cwd() {
     var file_url = [doc fileURL],
     file_path = [file_url path],
     base_dir = file_path.split([doc displayName])[0];
@@ -139,8 +145,7 @@ function get_cwd(){
 }
 
 // Let the user specify a directory
-function get_dir_from_prompt(){
-
+function get_dir_from_prompt() {
     var panel = [NSOpenPanel openPanel];
     [panel setMessage:"Where do you want to place your assets?"];
     [panel setCanChooseDirectories: true];
@@ -149,15 +154,13 @@ function get_dir_from_prompt(){
     var default_dir = [[doc fileURL] URLByDeletingLastPathComponent];
     [panel setDirectoryURL:default_dir];
 
-
-
-    if ([panel runModal] == NSOKButton){
-	var message = [panel filename];
-	return message;
+    if ([panel runModal] == NSOKButton) {
+        var message = [panel filename];
+        return message;
     }
 }
 
-function askForDefaultDensity(){
+function askForDefaultDensity() {
     var selectedItemIndex = 0;
     var items = ["mdpi","hdpi","xhdpi","xxhdpi","xxxhdpi"];
 
@@ -185,30 +188,30 @@ function askForDefaultDensity(){
 }
 
 function santize(fileName) {
-  return fileName.replace(/[^\w\d]/g, '_').toLowerCase();
+    return fileName.replace(/[^\w\d]/g, '_').toLowerCase();
 }
 
-function process_slice(slice, doc, base_dir, factors){
+function process_slice(slice, doc, base_dir, factors) {
     log("Will process slices");
     var frame = [slice frame];
     var slice_name = [slice name];
 
-    for (var name in factors){
-	var factor = factors[name];
-	log("Processing " + slice_name + " " + name + " (" + factor + ")");
-	var version = copy_layer_with_factor(slice, factor);
-	var file_name = base_dir + "/drawable-" + name + "/" + santize(slice_name) + ".png";
-	[doc saveArtboardOrSlice: version toFile:file_name];
-	log("Saved " + file_name);
+    for (var name in factors) {
+        var factor = factors[name];
+        log("Processing " + slice_name + " " + name + " (" + factor + ")");
+        var version = copy_layer_with_factor(slice, factor);
+        var file_name = base_dir + "/drawable-" + name + "/" + santize(slice_name) + ".png";
+        [doc saveArtboardOrSlice: version toFile:file_name];
+        log("Saved " + file_name);
     }
 }
 
-function copy_layer_with_factor(original_slice, factor){
-  var copy = [original_slice duplicate];
-  var rect = copy.className() == "MSArtboardGroup" ? rect = copy.absoluteRect().rect() : copy.absoluteInfluenceRect()
-  var slice = MSExportRequest.requestWithRect_scale(rect, factor)
-  [copy removeFromParent];
-  return slice;
+function copy_layer_with_factor(original_slice, factor) {
+    var copy = [original_slice duplicate];
+    var rect = copy.className() == "MSArtboardGroup" ? rect = copy.absoluteRect().rect() : copy.absoluteInfluenceRect()
+    var slice = MSExportRequest.requestWithRect_scale(rect, factor)
+    [copy removeFromParent];
+    return slice;
 }
 
 main();

--- a/Generate Android Assets.jstalk
+++ b/Generate Android Assets.jstalk
@@ -56,8 +56,7 @@ library.sandbox = {
             var fileManager = [NSFileManager defaultManager];
             var fileContents = [NSString stringWithContentsOfFile:configFile];
 
-            if (fileContents != null)
-            {
+            if (fileContents != null) {
                 if (hit = fileContents.match(/^base_density:([a-z]*)/)) {
                     var density = hit[1];
                     log("Found base density: " + density + ", returning");
@@ -65,9 +64,7 @@ library.sandbox = {
                 } else {
                     log("Found config file, but no base_density specified in it");
                 }
-            }
-            else
-            {
+            } else {
                 log("fileContents is null!");
             }
         }


### PR DESCRIPTION
I was getting errors in Sketch that were the result of fileContents being null (I assume because of a local issue on my machine), so when you run: `fileContents.match` (previously) on line 58, it would error since "null is not an object".  This fixes that. 

This PR also uses spaces for all formatting (just to improve readability and portability) and spaces between curly brackets and parentheses on control statements.

Feel free to reject if this isn't your preferred style and I'll update with your recommendations.